### PR TITLE
Fix typo in AWS MFA workflow message

### DIFF
--- a/plugins/aws/access_key_test.go
+++ b/plugins/aws/access_key_test.go
@@ -562,7 +562,7 @@ func TestResolveLocalAnd1PasswordConfigurations(t *testing.T) {
 				MfaToken:   "019879",
 				MfaProcess: "mfa login",
 			},
-			err: fmt.Errorf("only 1Password-backed OTP authentication is supported by the MFA worklfow of the AWS shell plugin"),
+			err: fmt.Errorf("only 1Password-backed OTP authentication is supported by the MFA workflow of the AWS shell plugin"),
 		},
 		{
 			description: "mfa data is present only in 1Password",

--- a/plugins/aws/sts_provisioner.go
+++ b/plugins/aws/sts_provisioner.go
@@ -231,7 +231,7 @@ func resolveLocalAnd1PasswordConfigurations(itemFields map[sdk.FieldName]string,
 
 	// only 1Password OTPs are supported
 	if awsConfig.MfaToken != "" || awsConfig.MfaProcess != "" || awsConfig.MfaPromptMethod != "" {
-		return fmt.Errorf("only 1Password-backed OTP authentication is supported by the MFA worklfow of the AWS shell plugin")
+		return fmt.Errorf("only 1Password-backed OTP authentication is supported by the MFA workflow of the AWS shell plugin")
 	}
 	// make sure 1Password OTP is used
 	if hasOTP {


### PR DESCRIPTION
## Summary
- fix spelling of `workflow` in AWS STS provisioner and its test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841615a310483338903b9c91957d152